### PR TITLE
(SIMP-618) Stdlib should be installed by default

### DIFF
--- a/build/package_metadata.yaml
+++ b/build/package_metadata.yaml
@@ -1,0 +1,2 @@
+---
+optional : false


### PR DESCRIPTION
Upated the package_metadata.yaml file.

SIMP-618 #comment Need stdlib by default
