### PR TITLE
[MODULES-10781] Fix defined type defined_with_params()

### DIFF
--- a/lib/puppet/parser/functions/defined_with_params.rb
+++ b/lib/puppet/parser/functions/defined_with_params.rb
@@ -54,12 +54,19 @@ DOC
                 [findresource(type, title)]
               end
 
-  resources.compact.each do |resource|
+  resources.compact.each do |res|
+    # If you call this from within a defined type, it will find itself
+    next if res.to_s == resource.to_s
+
     matches = params.map do |key, value|
       # eql? avoids bugs caused by monkeypatching in puppet
-      resource_is_undef = resource[key].eql?(:undef) || resource[key].nil?
+      res_is_undef = res[key].eql?(:undef) || res[key].nil?
       value_is_undef = value.eql?(:undef) || value.nil?
-      (resource_is_undef && value_is_undef) || (resource[key] == value)
+      found_match = (res_is_undef && value_is_undef) || (res[key] == value)
+
+      Puppet.debug("Matching resource is #{res}") if found_match
+
+      found_match
     end
     ret = params.empty? || !matches.include?(false)
 

--- a/spec/functions/defined_with_params_spec.rb
+++ b/spec/functions/defined_with_params_spec.rb
@@ -94,6 +94,26 @@ describe 'defined_with_params' do
     }
   end
 
+  describe 'when called from within a defined type looking for a defined type of the same type' do
+    let :pre_condition do
+      <<-PRECOND
+        define test::deftype(
+          Optional $port = undef
+        ) {
+          if defined_with_params(Test::Deftype, { 'port' => $port }) {
+            fail('Ruh Roh Shaggy')
+          }
+        }
+
+        test::deftype { 'foo': }
+        test::deftype { 'bar': port => 200 }
+      PRECOND
+    end
+
+    # Testing to make sure that the internal logic handles this case via the pre_condition
+    it { is_expected.to run.with_params('NoOp[noop]', {}).and_return(false) }
+  end
+
   describe 'when passed a class' do
     let :pre_condition do
       'class test () { } class { "test": }'


### PR DESCRIPTION
An edge case was missed previously where calling the
defined_with_params() function from inside a defined type on another
instance of the same defined type would always return a match because it
would match against itself.

This updates the code to ignore itself and also adds a debug line output
for any resource that was matched.

MODULES-10781 #close